### PR TITLE
Nextflow tuning options

### DIFF
--- a/hla_pipeline/hla_la.nf
+++ b/hla_pipeline/hla_la.nf
@@ -1,5 +1,9 @@
 
 process HLA_typing {
+	cache "lenient"
+	errorStrategy { sleep(Math.pow(2, task.attempt) * 200 as long); return "retry" }
+	maxRetries 3
+	scratch true
 
 	input:
 	tuple file (bam), file(bam_index) from Channel.fromPath("extracted/*.bam").map{ bam -> [ bam, bam + (bam.getExtension() == "bam" ? ".bai" : ".crai") ] }
@@ -31,6 +35,8 @@ process HLA_typing {
 }
 
 process merge {
+	cache "lenient"
+
 	input:
 	file(bestguess_files) from bestguess.collect()
 


### PR DESCRIPTION
"lenient" cache for NFS; automatically resubmits crashed jobs <=3 times; has a delay for job resubmission; uses local scratch to avoid network IO